### PR TITLE
Feat/400 intermediate steps + sbt assembly + spark-submit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,13 +19,8 @@ libraryDependencies += "org.apache.spark" %% "spark-sql" % spark_version % Provi
 libraryDependencies += "org.apache.hadoop" % "hadoop-common" % "3.3.0" % Provided
 libraryDependencies += "org.apache.hadoop" % "hadoop-client" % "3.3.0" % Provided
 libraryDependencies += "org.apache.hadoop" % "hadoop-aws" % "3.3.0" % Provided
-libraryDependencies += "io.projectglow" %% "glow-spark3" % "1.0.0" exclude ("org.apache.hadoop", "hadoop-client")
-libraryDependencies += "io.delta" %% "delta-core" % "0.8.0" % Provided
-libraryDependencies += "com.amazonaws" % "aws-java-sdk-bom" % "1.11.975"
-libraryDependencies += "com.amazonaws" % "aws-java-sdk-s3" % "1.11.975"
-libraryDependencies += "com.softwaremill.sttp.client3" %% "core" % "3.1.7"
-libraryDependencies += "com.google.code.gson" % "gson" % "2.8.6"
-libraryDependencies += "bio.ferlab" %% "datalake-spark3" % "0.0.41"
+libraryDependencies += "org.apache.httpcomponents" % "httpclient" % "4.5.13"
+libraryDependencies += "bio.ferlab" %% "datalake-spark3" % "0.0.54"
 libraryDependencies += "com.typesafe" % "config" % "1.4.1"
 libraryDependencies += "org.keycloak" % "keycloak-authz-client" % "12.0.3"
 
@@ -46,6 +41,8 @@ assemblyMergeStrategy in assembly := {
   case "git.properties" => MergeStrategy.discard
   case "mime.types" => MergeStrategy.first
   case PathList("scala", "annotation", "nowarn.class" | "nowarn$.class") => MergeStrategy.first
+  case PathList("module-info.class") => MergeStrategy.discard
+  case x if x.endsWith("/module-info.class") => MergeStrategy.discard
   case x =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(x)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,8 +1,9 @@
 keycloak {
-    auth-server-url=${?KEYCLOAK_URL}
     auth-server-url="http://localhost:8081/auth"
-    realm=${?KEYCLOAK_REALM}
+    auth-server-url=${?KEYCLOAK_URL}
     realm=master
+    realm=${?KEYCLOAK_REALM}
+    client-id="cqdg-system"
     client-id=${?KEYCLOAK_CLIENT_ID}
     secret-key=${?KEYCLOAK_SECRET_KEY}
     settings {
@@ -10,4 +11,31 @@ keycloak {
         type-prefix="urn:cqdg:resources:"
         scope="urn:cqdg:scopes:download"
     }
+}
+
+s3 {
+    endpoint="http://localhost:9000"
+    endpoint=${?SERVICE_ENDPOINT}
+    bucket="cqdg"
+    bucket=${?AWS_BUCKET}
+    region="us-east-1"
+    region=${?AWS_DEFAULT_REGION}
+    client-id="minio"
+    client-id=${?AWS_ACCESS_KEY_ID}
+    secret-key="minio123"
+    secret-key=${?AWS_SECRET_ACCESS_KEY}
+}
+
+pre-process {
+    logger="pre-process"
+    input="clinical-data"
+    output="clinical-data-with-ids"
+    format="tsv"
+    format=${?PRE_PROCESS_FORMAT}
+}
+
+process {
+    logger="process"
+    input="clinical-data-with-ids"
+    output="clinical-data-etl-indexer"
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -14,6 +14,26 @@ keycloak {
     }
 }
 
+id-server {
+    endpoint="http://localhost:5000"
+    endpoint=${?ID_SERVICE_HOST}
+    username=""
+    username=${?ID_SERVICE_USERNAME}
+    password=""
+    password=${?ID_SERVICE_PASSWORD}
+}
+
+lectern {
+    endpoint="http://localhost:3001"
+    endpoint=${?LECTERN_HOST}
+    username="lectern"
+    username=${?LECTERN_USERNAME}
+    password="changeMe"
+    password=${?LECTERN_PASSWORD}
+    dictionary-name="CQDG Data Dictionary"
+    dictionary-name=${?LECTERN_DICTIONARY_NAME}
+}
+
 s3 {
     endpoint="http://localhost:9000"
     endpoint=${?SERVICE_ENDPOINT}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -5,7 +5,8 @@ keycloak {
     realm=${?KEYCLOAK_REALM}
     client-id="cqdg-system"
     client-id=${?KEYCLOAK_CLIENT_ID}
-    secret-key=${?KEYCLOAK_SECRET_KEY}
+    secret-key=${KEYCLOAK_SECRET_KEY}
+    logger="keycloak"
     settings {
         enabled=true
         type-prefix="urn:cqdg:resources:"
@@ -30,7 +31,7 @@ pre-process {
     logger="pre-process"
     input="clinical-data"
     output="clinical-data-with-ids"
-    format="tsv"
+    format="parquet"
     format=${?PRE_PROCESS_FORMAT}
 }
 

--- a/src/main/scala/ca/cqdg/etl/EtlApp.scala
+++ b/src/main/scala/ca/cqdg/etl/EtlApp.scala
@@ -1,96 +1,9 @@
 package ca.cqdg.etl
 
-import ca.cqdg.etl.model.{NamedDataFrame, S3File}
-import ca.cqdg.etl.utils.EtlUtils.columns.notNullCol
-import ca.cqdg.etl.utils.EtlUtils.{getConfiguration, getDataframe, loadAll}
-import ca.cqdg.etl.utils.PreProcessingUtils.{getOntologyDfs, loadSchemas, preProcess}
-import ca.cqdg.etl.utils.S3Utils.writeSuccessIndicator
-import ca.cqdg.etl.utils.{DataAccessUtils, KeycloakUtils, S3Utils, Schema}
-import com.amazonaws.ClientConfiguration
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
-import org.apache.log4j.{Level, Logger}
-import org.apache.spark.sql.functions.lit
-import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
-import org.slf4j.LoggerFactory
-
-import java.util.concurrent.Executors
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService}
-
 object EtlApp extends App {
 
-  val log = LoggerFactory.getLogger(this.getClass)
+  PreProcess.run()
 
-  val filesPerFolder: Map[String, List[S3File]] = S3Utils.loadFileEntries(s3Bucket, "clinical-data", s3Client)
+  Process.run()
 
-  val dictionarySchemas: Map[String, List[Schema]] = loadSchemas()
-  val readyToProcess: Map[String, List[NamedDataFrame]] = preProcess(filesPerFolder, s3Bucket)(dictionarySchemas);
-
-  import spark.implicits._
-
-  val ontologyFiles = S3Utils.loadFileEntry(s3Bucket, "ontology-input", s3Client)
-  val ontologyDfs = getOntologyDfs(ontologyFiles)
-
-  readyToProcess.foreach { case (prefix, dfList) =>
-    val outputPath= s"s3a://${s3Bucket}/clinical-data-etl-indexer"
-
-    val studyNDF = getDataframe("study", dfList)
-    
-    val (donor, diagnosisPerDonorAndStudy, phenotypesPerStudyIdAndDonor, biospecimenWithSamples, file, treatmentsPerDonorAndStudy, exposuresPerDonorAndStudy, followUpsPerDonorAndStudy, familyHistoryPerDonorAndStudy, familyRelationshipPerDonorAndStudy) = loadAll(dfList)(ontologyDfs)
-
-    val dataAccessGroup = DataAccessUtils.computeDataAccessByEntityType(studyNDF.dataFrame, ontologyDfs("duo_code"))
-
-    val study: DataFrame = studyNDF.dataFrame
-      .join(dataAccessGroup, Seq("study_id"), "left")
-        .select(
-          $"*",
-          $"study_id" as "study_id_keyword",
-          $"short_name" as "short_name_keyword",
-        )
-        .drop("access_limitations", "access_requirements")
-        .withColumn("short_name", notNullCol($"short_name"))
-        .as("study")
-    
-      val inputData = Map(
-        "donor" -> donor,
-        "diagnosisPerDonorAndStudy" -> diagnosisPerDonorAndStudy,
-        "phenotypesPerStudyIdAndDonor" -> phenotypesPerStudyIdAndDonor,
-        "biospecimenWithSamples" -> biospecimenWithSamples,
-        "treatmentsPerDonorAndStudy" -> treatmentsPerDonorAndStudy,
-        "exposuresPerDonorAndStudy" -> exposuresPerDonorAndStudy,
-        "followUpsPerDonorAndStudy" -> followUpsPerDonorAndStudy,
-        "familyHistoryPerDonorAndStudy" -> familyHistoryPerDonorAndStudy,
-        "familyRelationshipPerDonorAndStudy" -> familyRelationshipPerDonorAndStudy,
-        "file" -> file)
-
-      Donor.run(study, studyNDF, inputData, ontologyDfs("duo_code"), s"$outputPath/donors" )
-      Study.run(study, studyNDF, inputData, ontologyDfs, s"$outputPath/studies")
-
-      val files = new FileIndex(study, studyNDF, inputData, ontologyDfs("duo_code"))(etlConfiguration);
-      val transformedFiles = files.transform(files.extract())
-
-      if(KeycloakUtils.isEnabled) {
-        val allFilesInternalIDs = transformedFiles.select("internal_file_id").distinct().as[String].collect().toSet
-        val future = KeycloakUtils.createResources(allFilesInternalIDs)
-        val resources = Await.result(future, Duration.Inf)
-        log.info(s"Successfully create ${resources.size} resources")
-      }
-
-      write(transformedFiles, s"$outputPath/files")
-
-      writeSuccessIndicator(s3Bucket, prefix, s3Client);
-  }
-
-  def write(files: DataFrame, outputPath: String)(implicit spark: SparkSession): Unit = {
-    files
-      .coalesce(1)
-      .write
-      .mode(SaveMode.Overwrite)
-      .partitionBy("study_id", "dictionary_version", "study_version", "study_version_creation_date")
-      .json(outputPath)
-  }
-
-  spark.stop()
 }

--- a/src/main/scala/ca/cqdg/etl/EtlApp.scala
+++ b/src/main/scala/ca/cqdg/etl/EtlApp.scala
@@ -11,6 +11,7 @@ import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import org.apache.log4j.{Level, Logger}
+import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.slf4j.LoggerFactory
 
@@ -20,54 +21,18 @@ import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorServic
 
 object EtlApp extends App {
 
-  Logger.getLogger("ferlab").setLevel(Level.INFO)
   val log = LoggerFactory.getLogger(this.getClass)
 
-  implicit val executorContext: ExecutionContextExecutorService =
-    ExecutionContext.fromExecutorService(Executors.newCachedThreadPool()) // better than scala global executor + keep the App alive until shutdown
-  // properly shutdown after app execution
-  sys.addShutdownHook(executorContext.shutdown)
-
-  implicit val spark: SparkSession = SparkSession
-    .builder
-    .appName("CQDG-ETL")
-    .master("local")//TODO: Remove "local" and replace by '[*]'
-    .getOrCreate()
-
-  // https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html#general_configuration
-  // The following env var must be set :
-  // SERVICE_ENDPOINT
-  // AWS_ACCESS_KEY_ID
-  // AWS_SECRET_ACCESS_KEY
-  // AWS_DEFAULT_REGION
-  val s3Endpoint = getConfiguration("SERVICE_ENDPOINT", "http://localhost:9000")
-  val s3Bucket: String = getConfiguration("AWS_BUCKET", "cqdg")
-
-  spark.sparkContext.hadoopConfiguration.set("fs.s3a.endpoint", s3Endpoint)
-  spark.sparkContext.hadoopConfiguration.set("fs.s3a.path.style.access", "true")
-
-  val clientConfiguration = new ClientConfiguration
-  clientConfiguration.setSignerOverride("AWSS3V4SignerType")
-
-  val s3Client: AmazonS3 = AmazonS3ClientBuilder.standard()
-    .withEndpointConfiguration(
-      new EndpointConfiguration(
-        getConfiguration("SERVICE_ENDPOINT", s3Endpoint),
-        getConfiguration("AWS_DEFAULT_REGION", Regions.US_EAST_1.name()))
-    )
-    .withPathStyleAccessEnabled(true)
-    .withClientConfiguration(clientConfiguration)
-    .build()
-
   val filesPerFolder: Map[String, List[S3File]] = S3Utils.loadFileEntries(s3Bucket, "clinical-data", s3Client)
-
-  val ontologyFiles = S3Utils.loadFileEntry(s3Bucket, "ontology-input", s3Client)
-  val ontologyDfs = getOntologyDfs(ontologyFiles)
 
   val dictionarySchemas: Map[String, List[Schema]] = loadSchemas()
   val readyToProcess: Map[String, List[NamedDataFrame]] = preProcess(filesPerFolder, s3Bucket)(dictionarySchemas);
 
   import spark.implicits._
+
+  val ontologyFiles = S3Utils.loadFileEntry(s3Bucket, "ontology-input", s3Client)
+  val ontologyDfs = getOntologyDfs(ontologyFiles)
+
   readyToProcess.foreach { case (prefix, dfList) =>
     val outputPath= s"s3a://${s3Bucket}/clinical-data-etl-indexer"
 

--- a/src/main/scala/ca/cqdg/etl/PreProcess.scala
+++ b/src/main/scala/ca/cqdg/etl/PreProcess.scala
@@ -6,60 +6,53 @@ import ca.cqdg.etl.utils.S3Utils.writeSuccessIndicator
 import ca.cqdg.etl.utils.{S3Utils, Schema}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.log4j.{Level, Logger}
+import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.functions.lit
-import org.apache.spark.sql.{DataFrame, SaveMode}
+import org.slf4j
 import org.slf4j.LoggerFactory
 
-object PreProcess extends App{
+object PreProcess {
 
   val preProcessConfig: Config = ConfigFactory.load.getObject("pre-process").toConfig
-  val preProcessLogger = preProcessConfig.getString("logger")
-  val preProcessInput = preProcessConfig.getString("input")
-  val preProcessOutput = preProcessConfig.getString("output")
-  val preProcessFormat = preProcessConfig.getString("format")
+  val preProcessLogger: String = preProcessConfig.getString("logger")
+  val preProcessInput: String = preProcessConfig.getString("input")
+  val preProcessOutput: String = preProcessConfig.getString("output")
+  val preProcessFormat: String = preProcessConfig.getString("format")
 
-  val log = LoggerFactory.getLogger(preProcessLogger)
+  val log: slf4j.Logger = LoggerFactory.getLogger(preProcessLogger)
   Logger.getLogger(preProcessLogger).setLevel(Level.INFO)
+
+  def main(args: Array[String]): Unit = {
+    run()
+  }
 
   def run(): Unit = {
     log.info("Looking for un-processed S3 files ...")
     val filesPerFolder: Map[String, List[S3File]] = S3Utils.loadFileEntries(s3Bucket, preProcessInput, s3Client)
-    log.info("Retrieving dictionary schemas ...")
-    val dictionarySchemas: Map[String, List[Schema]] = loadSchemas()
-    log.info("Pre-processing files ...")
-    val data = preProcess(filesPerFolder, s3Bucket)(dictionarySchemas)
 
-    data.foreach({ case (prefix, ndfList) =>
-      val outputFolder = prefix.replace(preProcessInput, preProcessOutput)
-      val outputPath= s"s3a://$s3Bucket/$outputFolder"
+    if (filesPerFolder.nonEmpty) {
+      log.info("Retrieving dictionary schemas ...")
+      val dictionarySchemas: Map[String, List[Schema]] = loadSchemas()
+      log.info(s"Pre-processing of ${filesPerFolder.size} folder(s) ...")
+      val data = preProcess(filesPerFolder, s3Bucket)(dictionarySchemas)
 
-      ndfList.foreach(ndf =>
-        transformAndWrite(ndf, outputPath)
-      )
+      data.foreach({ case (prefix, ndfList) =>
+        log.info(s"Pre-processing folder: $prefix")
+        val outputFolder = prefix.replace(preProcessInput, preProcessOutput)
+        val outputPath = s"s3a://$s3Bucket/$outputFolder"
 
-      writeSuccessIndicator(s3Bucket, prefix, s3Client);
-    })
+        ndfList.foreach(ndf =>
+          transformAndWrite(ndf, outputPath)
+        )
+
+        log.info(s"Successfully pre-processed: $prefix")
+        writeSuccessIndicator(s3Bucket, prefix, s3Client);
+      })
+    }
   }
 
   private def transformAndWrite(ndf: NamedDataFrame, outputPath: String): Unit = {
     val name = ndf.name
-
-    /*val fileName = name match {
-      case "donor" => "donor"
-      case "diagnosis" => "diagnosis"
-      case "phenotype" => "phenotype"
-      case "biospecimen" => "biospecimen"
-      case "sampleregistration" => "sample_registration"
-      case "treatment" => "treatment"
-      case "exposure" => "exposure"
-      case "followup" => "follow-up"
-      case "familyhistory" => "family-history"
-      case "family" => "family"
-      case "file" => "file"
-      case "study" => "study"
-      case _ => throw new RuntimeException(s"Unexpected input file with name: $name")
-    }*/
-
     var df = ndf.dataFrame
 
     if (name.equals("study")) {
@@ -74,32 +67,10 @@ object PreProcess extends App{
     log.info(s"Saving $output ...")
 
     preProcessFormat match {
-      case "tsv" => writeTSV(df, output)
-      case "parquet" => writeParquet(df, output)
+      case "tsv" => df.coalesce(1).write.options(tsv_with_headers).mode(SaveMode.Overwrite).csv(output)
+      case "parquet" => df.write.mode(SaveMode.Overwrite).parquet(output)
       case format => throw new RuntimeException(s"Unsupported pre-process format: $format")
     }
 
   }
-
-  private def writeTSV(df: DataFrame, output: String): Unit = {
-    df
-      .coalesce(1)
-      .write
-      .option("header", "true")
-      .option("delimiter", "\t")
-      .mode(SaveMode.Overwrite)
-      .csv(output)
-  }
-
-  private def writeParquet(df: DataFrame, output: String): Unit = {
-    df
-      .write
-      .mode(SaveMode.Overwrite)
-      .parquet(output)
-  }
-
-  run()
-
-  spark.stop()
-
 }

--- a/src/main/scala/ca/cqdg/etl/PreProcess.scala
+++ b/src/main/scala/ca/cqdg/etl/PreProcess.scala
@@ -1,0 +1,105 @@
+package ca.cqdg.etl
+
+import ca.cqdg.etl.model.{NamedDataFrame, S3File}
+import ca.cqdg.etl.utils.PreProcessingUtils.{loadSchemas, preProcess}
+import ca.cqdg.etl.utils.S3Utils.writeSuccessIndicator
+import ca.cqdg.etl.utils.{S3Utils, Schema}
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.log4j.{Level, Logger}
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.{DataFrame, SaveMode}
+import org.slf4j.LoggerFactory
+
+object PreProcess extends App{
+
+  val preProcessConfig: Config = ConfigFactory.load.getObject("pre-process").toConfig
+  val preProcessLogger = preProcessConfig.getString("logger")
+  val preProcessInput = preProcessConfig.getString("input")
+  val preProcessOutput = preProcessConfig.getString("output")
+  val preProcessFormat = preProcessConfig.getString("format")
+
+  val log = LoggerFactory.getLogger(preProcessLogger)
+  Logger.getLogger(preProcessLogger).setLevel(Level.INFO)
+
+  def run(): Unit = {
+    log.info("Looking for un-processed S3 files ...")
+    val filesPerFolder: Map[String, List[S3File]] = S3Utils.loadFileEntries(s3Bucket, preProcessInput, s3Client)
+    log.info("Retrieving dictionary schemas ...")
+    val dictionarySchemas: Map[String, List[Schema]] = loadSchemas()
+    log.info("Pre-processing files ...")
+    val data = preProcess(filesPerFolder, s3Bucket)(dictionarySchemas)
+
+    data.foreach({ case (prefix, ndfList) =>
+      val outputFolder = prefix.replace(preProcessInput, preProcessOutput)
+      val outputPath= s"s3a://$s3Bucket/$outputFolder"
+
+      ndfList.foreach(ndf =>
+        transformAndWrite(ndf, outputPath)
+      )
+
+      writeSuccessIndicator(s3Bucket, prefix, s3Client);
+    })
+  }
+
+  private def transformAndWrite(ndf: NamedDataFrame, outputPath: String): Unit = {
+    val name = ndf.name
+
+    /*val fileName = name match {
+      case "donor" => "donor"
+      case "diagnosis" => "diagnosis"
+      case "phenotype" => "phenotype"
+      case "biospecimen" => "biospecimen"
+      case "sampleregistration" => "sample_registration"
+      case "treatment" => "treatment"
+      case "exposure" => "exposure"
+      case "followup" => "follow-up"
+      case "familyhistory" => "family-history"
+      case "family" => "family"
+      case "file" => "file"
+      case "study" => "study"
+      case _ => throw new RuntimeException(s"Unexpected input file with name: $name")
+    }*/
+
+    var df = ndf.dataFrame
+
+    if (name.equals("study")) {
+      log.debug("Add meta-data columns to study")
+      df = df.withColumn("dictionary_version", lit(ndf.dictionaryVersion))
+        .withColumn("study_version", lit(ndf.studyVersion))
+        .withColumn("study_version_creation_date", lit(ndf.studyVersionCreationDate))
+    }
+
+    val output = s"$outputPath/$name"
+
+    log.info(s"Saving $output ...")
+
+    preProcessFormat match {
+      case "tsv" => writeTSV(df, output)
+      case "parquet" => writeParquet(df, output)
+      case format => throw new RuntimeException(s"Unsupported pre-process format: $format")
+    }
+
+  }
+
+  private def writeTSV(df: DataFrame, output: String): Unit = {
+    df
+      .coalesce(1)
+      .write
+      .option("header", "true")
+      .option("delimiter", "\t")
+      .mode(SaveMode.Overwrite)
+      .csv(output)
+  }
+
+  private def writeParquet(df: DataFrame, output: String): Unit = {
+    df
+      .write
+      .mode(SaveMode.Overwrite)
+      .parquet(output)
+  }
+
+  run()
+
+  spark.stop()
+
+}

--- a/src/main/scala/ca/cqdg/etl/Process.scala
+++ b/src/main/scala/ca/cqdg/etl/Process.scala
@@ -1,7 +1,6 @@
 package ca.cqdg.etl
 
-import ca.cqdg.etl.PreProcess.{log, preProcessInput}
-import ca.cqdg.etl.model.{NamedDataFrame, S3File}
+import ca.cqdg.etl.model.NamedDataFrame
 import ca.cqdg.etl.utils.EtlUtils.columns.notNullCol
 import ca.cqdg.etl.utils.EtlUtils.{getDataframe, loadAll}
 import ca.cqdg.etl.utils.PreProcessingUtils.getOntologyDfs
@@ -10,123 +9,101 @@ import ca.cqdg.etl.utils.{DataAccessUtils, KeycloakUtils, S3Utils}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.sql.{DataFrame, SaveMode}
+import org.slf4j
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-object Process extends App {
-
-  import spark.implicits._
+object Process {
 
   val preProcessConfig: Config = ConfigFactory.load.getObject("pre-process").toConfig
 
   val processConfig: Config = ConfigFactory.load.getObject("process").toConfig
-  val processLogger = processConfig.getString("logger")
-  val processInput = processConfig.getString("input")
-  val processOutput = processConfig.getString("output")
+  val processLogger: String = processConfig.getString("logger")
+  val processInput: String = processConfig.getString("input")
+  val processOutput: String = processConfig.getString("output")
 
-  val log = LoggerFactory.getLogger(processLogger)
+  val log: slf4j.Logger = LoggerFactory.getLogger(processLogger)
   Logger.getLogger(processLogger).setLevel(Level.INFO)
 
-  def buildNamedDataFrame(s3Bucket: String, files: Map[String, List[String]]): Map[String, List[NamedDataFrame]] = {
-     val ndfsByPath = files.map({case (path, files) =>
-        val dfs = files.map(file => {
-          val s3File = s"s3a://$s3Bucket//$file"
-          val dfName = file.substring(file.lastIndexOf("/") + 1)
-          val df = preProcessConfig.getString("format") match {
-            case "tsv" => spark.read.option("header", "true").option("delimiter", "\t").csv(s"$s3File/*.csv")
-            case "parquet" => spark.read.parquet(s3File)
-            case format => throw new RuntimeException(s"Unsupported pre-process format: $format")
-          }
-          if(dfName == "study") {
-            val metadatas = df.select("study_version","study_version_creation_date", "dictionary_version").distinct().first()
-            NamedDataFrame(dfName, df, metadatas.getString(0), metadatas.getString(1), metadatas.getString(2))
-          }else {
-            NamedDataFrame(dfName, df, null, null, null)
-          }
-        })
-       (path, dfs)
-     })
-    ndfsByPath.map({case (path, ndfs) =>
-      val studyNdf = ndfs.find(ndf => ndf.name.equals("study")).getOrElse(throw new RuntimeException("Can't find study NamedDataFrame in: " + path))
-      ndfs.foreach(otherNdf => {
-        if(!otherNdf.name.equals("study")) {
-          otherNdf.studyVersion = studyNdf.studyVersion
-          otherNdf.studyVersionCreationDate = studyNdf.studyVersionCreationDate
-          otherNdf.dictionaryVersion = studyNdf.dictionaryVersion
-        }
-      })
-      (path, ndfs)
-    })
+  def main(args: Array[String]): Unit = {
+    run()
   }
 
-  def run():Unit = {
-    log.info("Looking for un-processed S3 files ...")
+  def run(): Unit = {
+    log.info("Looking for pre-processed S3 files ...")
     val filesPerFolder: Map[String, List[String]] = S3Utils.loadPreProcessedEntries(s3Bucket, processInput, s3Client)
-    log.info("Preparing NamedDataFrames ... ...")
-    val readyToProcess: Map[String, List[NamedDataFrame]] = buildNamedDataFrame(s3Bucket, filesPerFolder)
-    log.info("Loading ontology files ...")
-    val ontologyFiles = S3Utils.loadFileEntry(s3Bucket, "ontology-input", s3Client)
-    log.info("Extracting ontology files ...")
-    val ontologyDfs = getOntologyDfs(ontologyFiles)
 
-    readyToProcess.foreach { case (prefix, dfList) =>
-      val outputPath= s"s3a://${s3Bucket}/$processOutput"
+    if (filesPerFolder.nonEmpty) {
+      log.info(s"Building NamedDataFrames of ${filesPerFolder.size} folder(s)...")
+      val readyToProcess: Map[String, List[NamedDataFrame]] = buildNamedDataFrame(s3Bucket, filesPerFolder)
+      log.info("Loading ontology files ...")
+      val ontologyFiles = S3Utils.loadFileEntry(s3Bucket, "ontology-input", s3Client)
+      log.info("Building ontology files ...")
+      val ontologyDfs = getOntologyDfs(ontologyFiles)
 
-      val studyNDF = getDataframe("study", dfList)
+      readyToProcess.foreach { case (prefix, dfList) =>
 
-      log.info("Computing PerDonorAndStudy ...")
-      val (donor, diagnosisPerDonorAndStudy, phenotypesPerStudyIdAndDonor, biospecimenWithSamples, file, treatmentsPerDonorAndStudy, exposuresPerDonorAndStudy, followUpsPerDonorAndStudy, familyHistoryPerDonorAndStudy, familyRelationshipPerDonorAndStudy) = loadAll(dfList)(ontologyDfs)
+        import spark.implicits._
 
-      log.info("Computing DataAccessGroup ...")
-      val dataAccessGroup = DataAccessUtils.computeDataAccessByEntityType(studyNDF.dataFrame, ontologyDfs("duo_code"))
+        val outputPath = s"s3a://${s3Bucket}/$processOutput"
 
-      val study: DataFrame = studyNDF.dataFrame
-        .join(dataAccessGroup, Seq("study_id"), "left")
-        .select(
-          $"*",
-          $"study_id" as "study_id_keyword",
-          $"short_name" as "short_name_keyword",
-        )
-        .drop("access_limitations", "access_requirements")
-        .withColumn("short_name", notNullCol($"short_name"))
-        .as("study")
+        val studyNDF = getDataframe("study", dfList)
 
-      val inputData = Map(
-        "donor" -> donor,
-        "diagnosisPerDonorAndStudy" -> diagnosisPerDonorAndStudy,
-        "phenotypesPerStudyIdAndDonor" -> phenotypesPerStudyIdAndDonor,
-        "biospecimenWithSamples" -> biospecimenWithSamples,
-        "treatmentsPerDonorAndStudy" -> treatmentsPerDonorAndStudy,
-        "exposuresPerDonorAndStudy" -> exposuresPerDonorAndStudy,
-        "followUpsPerDonorAndStudy" -> followUpsPerDonorAndStudy,
-        "familyHistoryPerDonorAndStudy" -> familyHistoryPerDonorAndStudy,
-        "familyRelationshipPerDonorAndStudy" -> familyRelationshipPerDonorAndStudy,
-        "file" -> file)
+        log.info("Computing PerDonorAndStudy ...")
+        val (donor, diagnosisPerDonorAndStudy, phenotypesPerStudyIdAndDonor, biospecimenWithSamples, file, treatmentsPerDonorAndStudy, exposuresPerDonorAndStudy, followUpsPerDonorAndStudy, familyHistoryPerDonorAndStudy, familyRelationshipPerDonorAndStudy) = loadAll(dfList)(ontologyDfs)
 
-      log.info("Computing Donor ...")
-      Donor.run(study, studyNDF, inputData, ontologyDfs("duo_code"), s"$outputPath/donors" )
-      log.info("Computing Study ...")
-      Study.run(study, studyNDF, inputData, ontologyDfs, s"$outputPath/studies")
-      log.info("Computing File ...")
-      val files = new FileIndex(study, studyNDF, inputData, ontologyDfs("duo_code"))(etlConfiguration);
-      val transformedFiles = files.transform(files.extract())
+        log.info("Computing DataAccessGroup ...")
+        val dataAccessGroup = DataAccessUtils.computeDataAccessByEntityType(studyNDF.dataFrame, ontologyDfs("duo_code"))
 
-      if(KeycloakUtils.isEnabled) {
-        val allFilesInternalIDs = transformedFiles.select("internal_file_id").distinct().as[String].collect().toSet
-        val future = KeycloakUtils.createResources(allFilesInternalIDs)
-        val resources = Await.result(future, Duration.Inf)
-        log.info(s"Successfully create ${resources.size} resources")
+        val study: DataFrame = studyNDF.dataFrame
+          .join(dataAccessGroup, Seq("study_id"), "left")
+          .select(
+            $"*",
+            $"study_id" as "study_id_keyword",
+            $"short_name" as "short_name_keyword",
+          )
+          .drop("access_limitations", "access_requirements")
+          .withColumn("short_name", notNullCol($"short_name"))
+          .as("study")
+
+        val inputData = Map(
+          "donor" -> donor,
+          "diagnosisPerDonorAndStudy" -> diagnosisPerDonorAndStudy,
+          "phenotypesPerStudyIdAndDonor" -> phenotypesPerStudyIdAndDonor,
+          "biospecimenWithSamples" -> biospecimenWithSamples,
+          "treatmentsPerDonorAndStudy" -> treatmentsPerDonorAndStudy,
+          "exposuresPerDonorAndStudy" -> exposuresPerDonorAndStudy,
+          "followUpsPerDonorAndStudy" -> followUpsPerDonorAndStudy,
+          "familyHistoryPerDonorAndStudy" -> familyHistoryPerDonorAndStudy,
+          "familyRelationshipPerDonorAndStudy" -> familyRelationshipPerDonorAndStudy,
+          "file" -> file)
+
+        log.info("Computing Donor ...")
+        Donor.run(study, studyNDF, inputData, ontologyDfs("duo_code"), s"$outputPath/donors")
+        log.info("Computing Study ...")
+        Study.run(study, studyNDF, inputData, ontologyDfs, s"$outputPath/studies")
+        log.info("Computing File ...")
+        val files = new FileIndex(study, studyNDF, inputData, ontologyDfs("duo_code"))(etlConfiguration);
+        val transformedFiles = files.transform(files.extract())
+
+        if (KeycloakUtils.isEnabled) {
+          val allFilesInternalIDs = transformedFiles.select("internal_file_id").distinct().as[String].collect().toSet
+          val future = KeycloakUtils.createResources(allFilesInternalIDs)
+          val resources = Await.result(future, Duration.Inf)
+          log.info(s"Successfully create ${resources.size} resources")
+        }
+
+        write(transformedFiles, s"$outputPath/files")
+
+        log.info(s"Successfully processed: $prefix")
+        writeSuccessIndicator(s3Bucket, prefix, s3Client);
       }
-
-      write(transformedFiles, s"$outputPath/files")
-
-      writeSuccessIndicator(s3Bucket, prefix, s3Client);
     }
   }
 
-  def write(files: DataFrame, outputPath: String): Unit = {
+  private def write(files: DataFrame, outputPath: String): Unit = {
     files
       .coalesce(1)
       .write
@@ -135,7 +112,39 @@ object Process extends App {
       .json(outputPath)
   }
 
-  run()
+  private def buildNamedDataFrame(s3Bucket: String, files: Map[String, List[String]]): Map[String, List[NamedDataFrame]] = {
+    val ndfsByPath = files.map({ case (path, files) =>
+      val dfs = files.map(file => {
+        val s3File = s"s3a://$s3Bucket//$file"
+        val dfName = file.substring(file.lastIndexOf("/") + 1) // df name is the name of the folder
+        val df = preProcessConfig.getString("format") match {
+          case "tsv" => spark.read.options(tsv_with_headers).csv(s"$s3File/*.csv")
+          case "parquet" => spark.read.parquet(s3File)
+          case format => throw new RuntimeException(s"Unsupported process format: $format")
+        }
+        if (dfName == "study") { // metadata are saved in the study df
+          val metadatas = df.select("study_version", "study_version_creation_date", "dictionary_version").distinct().first()
+          NamedDataFrame(dfName, df, metadatas.getString(0), metadatas.getString(1), metadatas.getString(2))
+        } else {
+          NamedDataFrame(dfName, df, null, null, null)
+        }
+      })
+      (path, dfs)
+    })
+    applyMetadata(ndfsByPath)
+  }
 
-  spark.stop()
+  private def applyMetadata(ndfsByPath: Map[String, List[NamedDataFrame]]): Map[String, List[NamedDataFrame]] = {
+    ndfsByPath.map({ case (path, ndfs) =>
+      val studyNdf = ndfs.find(ndf => ndf.name.equals("study")).getOrElse(throw new RuntimeException("Can't find study NamedDataFrame in: " + path))
+      ndfs.foreach(otherNdf => {
+        if (!otherNdf.name.equals("study")) {
+          otherNdf.studyVersion = studyNdf.studyVersion
+          otherNdf.studyVersionCreationDate = studyNdf.studyVersionCreationDate
+          otherNdf.dictionaryVersion = studyNdf.dictionaryVersion
+        }
+      })
+      (path, ndfs)
+    })
+  }
 }

--- a/src/main/scala/ca/cqdg/etl/Process.scala
+++ b/src/main/scala/ca/cqdg/etl/Process.scala
@@ -1,0 +1,141 @@
+package ca.cqdg.etl
+
+import ca.cqdg.etl.PreProcess.{log, preProcessInput}
+import ca.cqdg.etl.model.{NamedDataFrame, S3File}
+import ca.cqdg.etl.utils.EtlUtils.columns.notNullCol
+import ca.cqdg.etl.utils.EtlUtils.{getDataframe, loadAll}
+import ca.cqdg.etl.utils.PreProcessingUtils.getOntologyDfs
+import ca.cqdg.etl.utils.S3Utils.writeSuccessIndicator
+import ca.cqdg.etl.utils.{DataAccessUtils, KeycloakUtils, S3Utils}
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.log4j.{Level, Logger}
+import org.apache.spark.sql.{DataFrame, SaveMode}
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+object Process extends App {
+
+  import spark.implicits._
+
+  val preProcessConfig: Config = ConfigFactory.load.getObject("pre-process").toConfig
+
+  val processConfig: Config = ConfigFactory.load.getObject("process").toConfig
+  val processLogger = processConfig.getString("logger")
+  val processInput = processConfig.getString("input")
+  val processOutput = processConfig.getString("output")
+
+  val log = LoggerFactory.getLogger(processLogger)
+  Logger.getLogger(processLogger).setLevel(Level.INFO)
+
+  def buildNamedDataFrame(s3Bucket: String, files: Map[String, List[String]]): Map[String, List[NamedDataFrame]] = {
+     val ndfsByPath = files.map({case (path, files) =>
+        val dfs = files.map(file => {
+          val s3File = s"s3a://$s3Bucket//$file"
+          val dfName = file.substring(file.lastIndexOf("/") + 1)
+          val df = preProcessConfig.getString("format") match {
+            case "tsv" => spark.read.option("header", "true").option("delimiter", "\t").csv(s"$s3File/*.csv")
+            case "parquet" => spark.read.parquet(s3File)
+            case format => throw new RuntimeException(s"Unsupported pre-process format: $format")
+          }
+          if(dfName == "study") {
+            val metadatas = df.select("study_version","study_version_creation_date", "dictionary_version").distinct().first()
+            NamedDataFrame(dfName, df, metadatas.getString(0), metadatas.getString(1), metadatas.getString(2))
+          }else {
+            NamedDataFrame(dfName, df, null, null, null)
+          }
+        })
+       (path, dfs)
+     })
+    ndfsByPath.map({case (path, ndfs) =>
+      val studyNdf = ndfs.find(ndf => ndf.name.equals("study")).getOrElse(throw new RuntimeException("Can't find study NamedDataFrame in: " + path))
+      ndfs.foreach(otherNdf => {
+        if(!otherNdf.name.equals("study")) {
+          otherNdf.studyVersion = studyNdf.studyVersion
+          otherNdf.studyVersionCreationDate = studyNdf.studyVersionCreationDate
+          otherNdf.dictionaryVersion = studyNdf.dictionaryVersion
+        }
+      })
+      (path, ndfs)
+    })
+  }
+
+  def run():Unit = {
+    log.info("Looking for un-processed S3 files ...")
+    val filesPerFolder: Map[String, List[String]] = S3Utils.loadPreProcessedEntries(s3Bucket, processInput, s3Client)
+    log.info("Preparing NamedDataFrames ... ...")
+    val readyToProcess: Map[String, List[NamedDataFrame]] = buildNamedDataFrame(s3Bucket, filesPerFolder)
+    log.info("Loading ontology files ...")
+    val ontologyFiles = S3Utils.loadFileEntry(s3Bucket, "ontology-input", s3Client)
+    log.info("Extracting ontology files ...")
+    val ontologyDfs = getOntologyDfs(ontologyFiles)
+
+    readyToProcess.foreach { case (prefix, dfList) =>
+      val outputPath= s"s3a://${s3Bucket}/$processOutput"
+
+      val studyNDF = getDataframe("study", dfList)
+
+      log.info("Computing PerDonorAndStudy ...")
+      val (donor, diagnosisPerDonorAndStudy, phenotypesPerStudyIdAndDonor, biospecimenWithSamples, file, treatmentsPerDonorAndStudy, exposuresPerDonorAndStudy, followUpsPerDonorAndStudy, familyHistoryPerDonorAndStudy, familyRelationshipPerDonorAndStudy) = loadAll(dfList)(ontologyDfs)
+
+      log.info("Computing DataAccessGroup ...")
+      val dataAccessGroup = DataAccessUtils.computeDataAccessByEntityType(studyNDF.dataFrame, ontologyDfs("duo_code"))
+
+      val study: DataFrame = studyNDF.dataFrame
+        .join(dataAccessGroup, Seq("study_id"), "left")
+        .select(
+          $"*",
+          $"study_id" as "study_id_keyword",
+          $"short_name" as "short_name_keyword",
+        )
+        .drop("access_limitations", "access_requirements")
+        .withColumn("short_name", notNullCol($"short_name"))
+        .as("study")
+
+      val inputData = Map(
+        "donor" -> donor,
+        "diagnosisPerDonorAndStudy" -> diagnosisPerDonorAndStudy,
+        "phenotypesPerStudyIdAndDonor" -> phenotypesPerStudyIdAndDonor,
+        "biospecimenWithSamples" -> biospecimenWithSamples,
+        "treatmentsPerDonorAndStudy" -> treatmentsPerDonorAndStudy,
+        "exposuresPerDonorAndStudy" -> exposuresPerDonorAndStudy,
+        "followUpsPerDonorAndStudy" -> followUpsPerDonorAndStudy,
+        "familyHistoryPerDonorAndStudy" -> familyHistoryPerDonorAndStudy,
+        "familyRelationshipPerDonorAndStudy" -> familyRelationshipPerDonorAndStudy,
+        "file" -> file)
+
+      log.info("Computing Donor ...")
+      Donor.run(study, studyNDF, inputData, ontologyDfs("duo_code"), s"$outputPath/donors" )
+      log.info("Computing Study ...")
+      Study.run(study, studyNDF, inputData, ontologyDfs, s"$outputPath/studies")
+      log.info("Computing File ...")
+      val files = new FileIndex(study, studyNDF, inputData, ontologyDfs("duo_code"))(etlConfiguration);
+      val transformedFiles = files.transform(files.extract())
+
+      if(KeycloakUtils.isEnabled) {
+        val allFilesInternalIDs = transformedFiles.select("internal_file_id").distinct().as[String].collect().toSet
+        val future = KeycloakUtils.createResources(allFilesInternalIDs)
+        val resources = Await.result(future, Duration.Inf)
+        log.info(s"Successfully create ${resources.size} resources")
+      }
+
+      write(transformedFiles, s"$outputPath/files")
+
+      writeSuccessIndicator(s3Bucket, prefix, s3Client);
+    }
+  }
+
+  def write(files: DataFrame, outputPath: String): Unit = {
+    files
+      .coalesce(1)
+      .write
+      .mode(SaveMode.Overwrite)
+      .partitionBy("study_id", "dictionary_version", "study_version", "study_version_creation_date")
+      .json(outputPath)
+  }
+
+  run()
+
+  spark.stop()
+}

--- a/src/main/scala/ca/cqdg/etl/model/NamedDataFrame.scala
+++ b/src/main/scala/ca/cqdg/etl/model/NamedDataFrame.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.DataFrame
 case class NamedDataFrame(
                            name: String,
                            dataFrame: DataFrame,
-                           studyVersion: String,
-                           studyVersionCreationDate: String,
-                           dictionaryVersion: String
+                           var studyVersion: String,
+                           var studyVersionCreationDate: String,
+                           var dictionaryVersion: String
                          )

--- a/src/main/scala/ca/cqdg/etl/package.scala
+++ b/src/main/scala/ca/cqdg/etl/package.scala
@@ -32,7 +32,7 @@ package object etl {
   implicit val spark: SparkSession = SparkSession
     .builder
     .appName("CQDG-ETL")
-    .master("local")//TODO: Remove "local" and replace by '[*]'
+    //.master("local")
     .getOrCreate()
 
   val s3Config: Config = ConfigFactory.load.getObject("s3").toConfig

--- a/src/main/scala/ca/cqdg/etl/package.scala
+++ b/src/main/scala/ca/cqdg/etl/package.scala
@@ -47,6 +47,7 @@ package object etl {
   spark.sparkContext.hadoopConfiguration.set("fs.s3a.path.style.access", "true")
   spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", s3ClientId)
   spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", s3SecretKey)
+  sys.addShutdownHook(spark.stop())
 
   val clientConfiguration = new ClientConfiguration
   clientConfiguration.setSignerOverride("AWSS3V4SignerType")

--- a/src/main/scala/ca/cqdg/etl/package.scala
+++ b/src/main/scala/ca/cqdg/etl/package.scala
@@ -3,6 +3,18 @@ package ca.cqdg
 import bio.ferlab.datalake.spark3.config.{Configuration, DatasetConf, StorageConf}
 import bio.ferlab.datalake.spark3.loader.Format.{CSV, JSON, PARQUET}
 import bio.ferlab.datalake.spark3.loader.LoadType.OverWrite
+import ca.cqdg.etl.utils.EtlUtils.getConfiguration
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.log4j.{Level, Logger}
+import org.apache.spark.sql.SparkSession
+
+import java.util.concurrent.Executors
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 
 package object etl {
 
@@ -11,6 +23,41 @@ package object etl {
   val clinical_data_etl_indexer: String = "clinical-data-etl-indexer"
   val tsv_with_headers = Map("sep" -> "\t", "header" -> "true")
   val tsv_without_headers = Map("sep" -> "\t", "header" -> "false")
+
+  implicit val executorContext: ExecutionContextExecutorService =
+    ExecutionContext.fromExecutorService(Executors.newCachedThreadPool()) // better than scala global executor + keep the App alive until shutdown
+  // properly shutdown after app execution
+  sys.addShutdownHook(executorContext.shutdown())
+
+  implicit val spark: SparkSession = SparkSession
+    .builder
+    .appName("CQDG-ETL")
+    .master("local")//TODO: Remove "local" and replace by '[*]'
+    .getOrCreate()
+
+  val s3Config: Config = ConfigFactory.load.getObject("s3").toConfig
+  val s3Endpoint: String = s3Config.getString("endpoint")
+  val s3Bucket: String = s3Config.getString("bucket")
+  val s3Region: String = s3Config.getString("region")
+  val s3ClientId: String =s3Config.getString("client-id")
+  val s3SecretKey: String =s3Config.getString("secret-key")
+
+  spark.sparkContext.setLogLevel("WARN")
+  spark.sparkContext.hadoopConfiguration.set("fs.s3a.endpoint", s3Endpoint)
+  spark.sparkContext.hadoopConfiguration.set("fs.s3a.path.style.access", "true")
+  spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", s3ClientId)
+  spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", s3SecretKey)
+
+  val clientConfiguration = new ClientConfiguration
+  clientConfiguration.setSignerOverride("AWSS3V4SignerType")
+
+  val s3Client: AmazonS3 = AmazonS3ClientBuilder
+    .standard()
+    .withEndpointConfiguration(new EndpointConfiguration(s3Endpoint, s3Region))
+    .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(s3ClientId, s3SecretKey)))
+    .withPathStyleAccessEnabled(true)
+    .withClientConfiguration(clientConfiguration)
+    .build()
 
   val etlConfiguration: Configuration = Configuration(
     storages = List(

--- a/src/main/scala/ca/cqdg/etl/utils/BaseHttpClient.scala
+++ b/src/main/scala/ca/cqdg/etl/utils/BaseHttpClient.scala
@@ -1,0 +1,33 @@
+package ca.cqdg.etl.utils
+
+import org.apache.commons.lang3.StringUtils
+import org.apache.http.{HttpHeaders, HttpResponse}
+import org.apache.http.client.methods.HttpRequestBase
+import org.apache.http.impl.client.{CloseableHttpClient, HttpClientBuilder}
+import org.apache.http.util.EntityUtils
+
+import java.util.Base64
+
+class BaseHttpClient {
+
+  val httpBuilder: HttpClientBuilder = HttpClientBuilder.create()
+  val http: CloseableHttpClient = httpBuilder.build()
+  val charsetUTF8 = "UTF-8"
+  sys.addShutdownHook(http.close())
+
+  def addBasicAuth(httpRequest: HttpRequestBase, username: String, password: String): Unit = {
+    if(StringUtils.isNoneBlank(username, password)) {
+      val auth = Base64.getEncoder().encodeToString((s"$username:$password").getBytes(charsetUTF8));
+      httpRequest.addHeader(HttpHeaders.AUTHORIZATION, s"Basic $auth")
+    }
+  }
+
+  protected def executeHttpRequest(request: HttpRequestBase): (Option[String], Int) = {
+    val response: HttpResponse = http.execute(request)
+    val body = Option(response.getEntity).map(e => EntityUtils.toString(e, charsetUTF8))
+    // always properly close
+    EntityUtils.consumeQuietly(response.getEntity)
+    (body, response.getStatusLine.getStatusCode)
+  }
+
+}

--- a/src/main/scala/ca/cqdg/etl/utils/KeycloakUtils.scala
+++ b/src/main/scala/ca/cqdg/etl/utils/KeycloakUtils.scala
@@ -1,6 +1,7 @@
 package ca.cqdg.etl.utils
 
 import com.typesafe.config.ConfigFactory
+import org.apache.log4j.{Level, Logger}
 import org.keycloak.authorization.client.{AuthzClient, Configuration}
 import org.keycloak.representations.idm.authorization.{ResourceRepresentation, ScopeRepresentation}
 import org.slf4j.LoggerFactory
@@ -10,7 +11,6 @@ import scala.concurrent.{ExecutionContextExecutorService, Future}
 
 object KeycloakUtils {
 
-  private val log = LoggerFactory.getLogger(this.getClass)
   private val config = ConfigFactory.load.getObject("keycloak").toConfig
   private val keycloakAuthClientConfig = new Configuration(
     config.getString("auth-server-url"),
@@ -18,6 +18,10 @@ object KeycloakUtils {
     config.getString("client-id"),
     Collections.singletonMap("secret", config.getString("secret-key")),
     null) // keycloak API will create a default httpClient
+
+  private val keycloakLogger = config.getString("logger")
+  private val log = LoggerFactory.getLogger(keycloakLogger)
+  Logger.getLogger(keycloakLogger).setLevel(Level.INFO)
 
   val isEnabled: Boolean = config.getBoolean("settings.enabled")
 

--- a/src/main/scala/ca/cqdg/etl/utils/S3Utils.scala
+++ b/src/main/scala/ca/cqdg/etl/utils/S3Utils.scala
@@ -22,15 +22,41 @@ object S3Utils {
       pageKeys ::: objects
   }
 
-  def loadFileEntries(bucket: String, prefix: String, s3Client: AmazonS3): Map[String, List[S3File]] = {
+  def loadFileEntries(bucket: String, prefix: String, s3Client: AmazonS3, hasMetadata: Boolean = true): Map[String, List[S3File]] = {
     val fileEntries = ls(bucket, prefix, s3Client)
     // Group by "folder" and remove all "folders" not containing a study_version_metadata.json file.
     val filesGroupedByKey = fileEntries
       .groupBy(f => f.parentKey)
       .filter(entry =>
-        entry._2.exists(f => f.filename == "study_version_metadata.json") &&
+        (!hasMetadata || entry._2.exists(f => f.filename == "study_version_metadata.json")) &&
         !entry._2.exists(f => f.filename == "_SUCCESS"))  // Indicator that it has already been processed
     filesGroupedByKey
+  }
+
+  def loadPreProcessedEntries(bucket: String, prefix: String, s3Client: AmazonS3): Map[String, List[String]] = {
+
+    val filesGroupedByKey = ls(bucket, prefix, s3Client) // list all S3 files
+      .groupBy(f => f.parentKey)
+      .filter(entry => entry._2.exists(f => f.filename == "_SUCCESS")) // only if successfully saved by spark
+
+
+    val filesGroupedBySameFolder = filesGroupedByKey.map({case(path, _) =>
+      val parent =  path.substring(0, path.lastIndexOf("/"))  // extract parent name
+      val files = filesGroupedByKey
+        .filter(entry => entry._1.contains(parent)) // if same parent then group in same set
+        .values.flatten   // List[List[S3File] => List[S3File]
+        .map(f => f.parentKey)
+        .toList.distinct  // avoid duplicates
+      (parent, files)
+    })
+
+    // filter folders that have already been processed (contains a _SUCCESS file)
+    val filterOnlyNotProcessed = filesGroupedBySameFolder.filter({case (path, _) =>
+      val alreadyProcessed = s3Client.doesObjectExist(bucket, s"$path/_SUCCESS")
+      !alreadyProcessed
+    })
+
+    filterOnlyNotProcessed
   }
 
   def loadFileEntry(bucket: String, prefix: String, s3Client: AmazonS3) = {

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,6 @@
+keycloak {
+    secret-key="foo"
+    settings {
+        enabled=false
+    }
+}

--- a/src/test/resources/tsv/input/donor.tsv
+++ b/src/test/resources/tsv/input/donor.tsv
@@ -60,7 +60,7 @@ ST0001	PT00058	5/7/1958	63	6/16/2009	51	44	Female	Other	alive			FALSE	FALSE	TRUE
 ST0001	PT00059	6/10/1967	54	8/21/2008	41	33	Female	African or Carabean	alive			FALSE	FALSE	TRUE	FALSE	FALSE	FALSE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00060	2/21/1951	70	5/10/2009	58	48	Female	French Canadian 	alive			FALSE	FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00061	4/30/1967	54	12/14/2008	41	39	Female	French Canadian 	alive			FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	Not applicable	Not applicable	1	1				
-ST0001	PT00062	8/19/1957	63	7/16/2009	51	42	Female	French Canadian 	alive 			TRUE	FALSE	TRUE	FALSE	TRUE	TRUE	TRUE	Not applicable	Not applicable	1	1				
+ST0001	PT00062	8/19/1957	63	7/16/2009	51	42	Female	French Canadian 	alive			TRUE	FALSE	TRUE	FALSE	TRUE	TRUE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00063	1/21/1954	67	8/1/2008	54	46	Male	French Canadian 	alive			TRUE	FALSE	TRUE	FALSE	TRUE	TRUE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00064	12/30/1941	79	3/9/2009	67	65	Female	European	alive			TRUE	FALSE	TRUE	FALSE	TRUE	TRUE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00065	10/31/1946	74	11/10/2009	63	57	Female	French Canadian 	deceased	Chronic lower respiratory disease	26645	TRUE	FALSE	TRUE	TRUE	FALSE	TRUE	FALSE	Not applicable	Not applicable	1	1				
@@ -70,7 +70,7 @@ ST0001	PT00068	5/26/1949	72	12/5/2009	60	56	Female	Mixted descent	alive			TRUE	F
 ST0001	PT00069	9/18/1948	72	2/24/2009	60	58	Female	Arab	alive			TRUE	FALSE	TRUE	FALSE	FALSE	TRUE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00070	10/11/1959	61	9/9/2008	48	39	Female	European	alive			FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00071	12/18/1940	80	5/22/2009	68	62	Unknown	European	alive			FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	TRUE	Not applicable	Not applicable	1	1				
-ST0001	PT00072	12/27/1942	78	12/21/2008	65	64	Female	Aboriginal	alive 			FALSE	FALSE	TRUE	FALSE	FALSE	FALSE	FALSE	Not applicable	Not applicable	1	1				
+ST0001	PT00072	12/27/1942	78	12/21/2008	65	64	Female	Aboriginal	alive			FALSE	FALSE	TRUE	FALSE	FALSE	FALSE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00073	10/11/1944	76	6/30/2009	64	56	Female	Mixted descent	alive			FALSE	FALSE	TRUE	FALSE	FALSE	FALSE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00074	9/12/1945	75	3/23/2009	63	56	Male	European	alive			FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00075	2/13/1959	62	7/17/2009	50	43	Male	French Canadian 	deceased	Cerebrovascular disease	20805	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	TRUE	Not applicable	Not applicable	1	1				
@@ -80,7 +80,7 @@ ST0001	PT00078	2/11/1942	79	4/28/2009	67	65	Female	French Canadian 	alive			TRUE
 ST0001	PT00079	4/4/1943	78	6/11/2009	66	63	Female	Aboriginal	alive			TRUE	FALSE	TRUE	FALSE	TRUE	TRUE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00080	5/19/1941	80	10/20/2008	67	66	Female	Arab	alive			TRUE	FALSE	TRUE	FALSE	TRUE	TRUE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00081	8/27/1964	56	5/1/2009	44	39	Female	European	alive			TRUE	FALSE	FALSE	TRUE	FALSE	TRUE	TRUE	Not applicable	Not applicable	1	1				
-ST0001	PT00082	1/12/1971	50	9/22/2008	37	29	Female	European	alive 			TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	Not applicable	Not applicable	1	1				
+ST0001	PT00082	1/12/1971	50	9/22/2008	37	29	Female	European	alive			TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00083	10/10/1969	51	11/3/2009	40	36	Male	European	alive			TRUE	FALSE	TRUE	TRUE	FALSE	TRUE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00084	1/9/1954	67	12/19/2008	54	51	Male	East and Southeast Asian	alive			TRUE	FALSE	TRUE	FALSE	FALSE	TRUE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00085	5/25/1946	75	8/18/2008	62	59	Male	French Canadian 	deceased	Influenza and pneumonia	25550	FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	TRUE	Not applicable	Not applicable	1	1				
@@ -90,7 +90,7 @@ ST0001	PT00088	6/12/1947	74	5/2/2009	61	53	Female	French Canadian 	alive			FALSE
 ST0001	PT00089	1/31/1948	73	2/7/2009	61	53	Male	Arab	alive			FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00090	6/26/1962	59	8/16/2008	46	41	Male	East and Southeast Asian	alive			FALSE	FALSE	TRUE	FALSE	FALSE	FALSE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00091	11/2/1954	66	9/24/2008	53	43	Male	European	alive			FALSE	FALSE	TRUE	FALSE	FALSE	FALSE	FALSE	Not applicable	Not applicable	1	1				
-ST0001	PT00092	4/17/1962	59	7/30/2009	47	47	Female	European	alive 			FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	FALSE	Not applicable	Not applicable	1	1				
+ST0001	PT00092	4/17/1962	59	7/30/2009	47	47	Female	European	alive			FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00093	3/7/1959	62	8/22/2008	49	44	Male	French Canadian 	alive			FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00094	4/10/1939	82	12/9/2009	70	70	Female	French Canadian 	alive			FALSE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00095	11/4/1956	64	8/17/2009	52	50	Female	Other	deceased	Unknown	21535	FALSE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	Not applicable	Not applicable	1	1				
@@ -100,7 +100,7 @@ ST0001	PT00098	4/10/1955	66	10/15/2008	53	48	Female	European	alive			TRUE	FALSE	
 ST0001	PT00099	10/4/1965	55	12/4/2009	44	42	Male	Mixted descent	alive			TRUE	FALSE	TRUE	FALSE	TRUE	TRUE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00100	11/20/1940	80	12/25/2008	68	62	Male	European	alive			TRUE	FALSE	TRUE	FALSE	TRUE	TRUE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00101	1/21/1970	51	10/4/2008	38	29	Female	French Canadian 	alive			TRUE	FALSE	FALSE	TRUE	FALSE	TRUE	FALSE	Not applicable	Not applicable	1	1				
-ST0001	PT00102	4/29/1947	74	8/17/2008	61	53	Male	French Canadian 	alive 			TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	Not applicable	Not applicable	1	1				
+ST0001	PT00102	4/29/1947	74	8/17/2008	61	53	Male	French Canadian 	alive			TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00103	5/26/1955	66	9/9/2009	54	49	Male	French Canadian 	alive			TRUE	FALSE	TRUE	TRUE	FALSE	FALSE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00104	7/23/1968	52	6/6/2009	40	35	Female	French Canadian 	alive			TRUE	FALSE	TRUE	FALSE	FALSE	FALSE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00105	9/7/1958	62	8/16/2009	50	47	Unknown	French Canadian 	deceased	Influenza and pneumonia	19710	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE	TRUE	Not applicable	Not applicable	1	1				
@@ -110,7 +110,7 @@ ST0001	PT00108	8/11/1960	60	10/19/2009	49	43	Female	French Canadian 	alive			FAL
 ST0001	PT00109	11/3/1959	61	9/17/2008	48	42	Female	French Canadian 	alive			FALSE	FALSE	FALSE	FALSE	FALSE	TRUE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00110	6/19/1967	54	11/11/2008	41	34	Female	French Canadian 	alive			FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	TRUE	Not applicable	Not applicable	1	1				
 ST0001	PT00111	3/28/1940	81	1/7/2009	68	65	Male	European	alive			FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	TRUE	Not applicable	Not applicable	1	1				
-ST0001	PT00112	9/12/1956	64	10/16/2008	52	49	Male	European	alive 			FALSE	FALSE	TRUE	FALSE	FALSE	FALSE	FALSE	Not applicable	Not applicable	1	1				
+ST0001	PT00112	9/12/1956	64	10/16/2008	52	49	Male	European	alive			FALSE	FALSE	TRUE	FALSE	FALSE	FALSE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00113	9/4/1948	72	7/24/2008	59	59	Female	European	alive			FALSE	FALSE	TRUE	FALSE	FALSE	TRUE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00114	8/31/1969	51	9/26/2008	39	29	Female	French Canadian 	alive			FALSE	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE	Not applicable	Not applicable	1	1				
 ST0001	PT00115	11/29/1962	58	8/14/2008	45	37	Male	African or Carabean	deceased	Unknown	18980	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	Not applicable	Not applicable	1	1				

--- a/src/test/scala/ca/cqdg/etl/DonorSpec.scala
+++ b/src/test/scala/ca/cqdg/etl/DonorSpec.scala
@@ -1,6 +1,5 @@
 package ca.cqdg.etl
 
-import ca.cqdg.etl.EtlApp.ontologyDfs
 import ca.cqdg.etl.model.{NamedDataFrame, S3File}
 import ca.cqdg.etl.testutils.TestData.hashCodesList
 import ca.cqdg.etl.testutils.WithSparkSession


### PR DESCRIPTION
ETL is now performing intermediate steps.

clinical-data/ (TSV) -> clinical-data-with-ids/ (parquet) -> clinical-data-etl-indexer/ (JSON)

and put all configuration in application.conf instead of being everywhere

- [x] should work with spark-submit (fix assembly + deps + un-necessary code)

example :
sbt clean assembly
export KEYCLOAK_SECRET_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
spark-submit --master local --packages org.apache.hadoop:hadoop-aws:3.2.0 --class ca.cqdg.etl.EtlApp target/scala-2.12/cqdg-etl.jar